### PR TITLE
dmesg outputs are overcome with [madness]

### DIFF
--- a/include/madcap.h
+++ b/include/madcap.h
@@ -20,6 +20,10 @@
 
 #include <linux/netdevice.h>
 
+/* common prefix used by pr_<> macros */
+#undef pr_fmt
+#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
+
 enum madcap_obj_id {
 	MADCAP_OBJ_ID_UNDEFINED,
 	MADCAP_OBJ_ID_LLT_OFFSET,


### PR DESCRIPTION
Before

``` bash
[  840.757752] madcap (0.0.0) is loaded
[  848.873947] madcap (0.0.0) is unloaded
```

After

``` bash
[  792.806909] madcap: module verification failed: signature and/or required key missing - tainting kernel
[  792.807279] madcap: madcap (0.0.0) is loaded
[  811.528527] madcap: madcap (0.0.0) is unloaded
```
